### PR TITLE
when post, put with json body, it is not working, so fix it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,16 @@ const httpProxyMiddleware = async (
     if (pathRewrite) {
       req.url = rewritePath(req.url as string, pathRewrite);
     }
+    if(["POST", "PUT"].indexOf(req.method as string) >= 0 && typeof req.body === "object"){
+      req.body = JSON.stringify(req.body);
+    }
     proxy
+      .once("proxyReq", ((proxyReq: any, req: any): void => {
+        if(["POST", "PUT"].indexOf(req.method as string) >= 0 && typeof req.body === "string"){
+          proxyReq.write(req.body);
+          proxyReq.end();
+        }
+      }) as any)
       .once("proxyRes", resolve)
       .once("error", reject)
       .web(req, res, {


### PR DESCRIPTION
I had a some problem with next-http-proxy-middleware.
normally, GET and DELETE method are fine.
but when I use POST and PUT method with json body, it  just hang and never arrive at the target server.

so I googled it and found this : https://github.com/http-party/node-http-proxy/issues/180#issuecomment-191098037

with this code, I have no problem with POST and GET.