### PR TITLE
Change http-proxy & types into dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1228,7 +1228,6 @@
       "version": "1.17.3",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.3.tgz",
       "integrity": "sha512-wIPqXANye5BbORbuh74exbwNzj+UWCwWyeEFJzUQ7Fq3W2NSAy+7x7nX1fgbEypr2/TdKqpeuxLnXWgzN533/Q==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1277,8 +1276,7 @@
     "@types/node": {
       "version": "13.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
-      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
-      "dev": true
+      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3666,8 +3664,7 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.2.0",
@@ -4037,8 +4034,7 @@
     "follow-redirects": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
-      "dev": true
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -4524,7 +4520,6 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -8435,8 +8430,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "Yongwoo Jung<stegano@naver.com>",
     "Denny Lim<hi.iamdenny@gmail.com>"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@types/http-proxy": "1.17.3",
+    "http-proxy": "^1.18.1"
+  },
   "devDependencies": {
     "@types/jest": "^25.1.3",
-    "@types/http-proxy": "1.17.3",
     "typescript": "^3.8.2",
-    "http-proxy": "^1.18.1",
     "jest": "^26.6.3",
     "next": "^10.0.5",
     "rollup": "^2.38.0",


### PR DESCRIPTION
I believe these dependencies needs to lie in the `dependencies` array so that they're accessible to consumers of your library.

Installing version 1.0.8 yields Typescript errors whenever I try to add any `NextHttpProxyMiddlewareOptions` originating from `@types/http-proxy`, e.g.:

```
import { NextApiRequest, NextApiResponse } from "next";
import proxy from "next-http-proxy-middleware";

const handler = async (req: NextApiRequest, res: NextApiResponse) => {
  return proxy(req, res, {
    target: "http://some-target.url"
  });
};

export default handler;
```
Error:
```
Argument of type '{ target: string | undefined; }' is not assignable to parameter of type 'NextHttpProxyMiddlewareOptions'.
  Object literal may only specify known properties, and 'target' does not exist in type 'NextHttpProxyMiddlewareOptions'.
```

The same version also yields runtime errors, since `http-proxy` isn't installed: `Error: Cannot find module 'http-proxy'`.