### PR TITLE
Change the Content-Length to actual size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ const httpProxyMiddleware = async (
     proxy
       .once("proxyReq", ((proxyReq: any, req: any): void => {
         if (hasRequestBodyMethods.indexOf(req.method as string) >= 0 && typeof req.body === "string") {
+          proxyReq.setHeader("Content-Length", Buffer.byteLength(req.body));
           proxyReq.write(req.body);
           proxyReq.end();
         }


### PR DESCRIPTION
I'm changing the body of request before _httpProxyMiddleware_ function, & Server keep giving **400 Bad Request** error.

Later I recognize that we also need to define the length of data before request. That's why I've added this code to set `Content-Length` to actual size again.